### PR TITLE
Synced folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ downloads
 package.box
 testjp2
 testtif
+
+#hide local machine sites all
+sites/all/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,9 @@ package.box
 testjp2
 testtif
 
-#hide local machine sites all
-sites/all/*
+# hide local machine sites all
+sites/all
+
+# IDE stuff
+.idea
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ testtif
 
 # hide local machine sites all
 sites/all
+sites/all/*
 
 # IDE stuff
 .idea

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = $hostname
 
   # add synced_folder
-  config.vm.synced_folder "sites/all", "/vhosts/digital/web/collections/sites/all"
-
+  config.vm.synced_folder "sites/all", "/vhosts/digital/web/collections/sites/all",
+    owner: "vagrant",
+    group: "apache",
+    mount_options: ["dmode=775,fmode=664"]
+    
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "utkdigitalbase"
   config.vm.box_url = "http://dlweb.lib.utk.edu/vboxes/utkdigitalbase.json"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   unless  $forward.eql? "FALSE"  
     config.vm.network :forwarded_port, guest: 8080, host: 8080 # Tomcat
-    config.vm.network :forwarded_port, guest: 3306, host: 3306 # MySQL
+    config.vm.network :forwarded_port, guest: 3306, host: 3307 # MySQL
     config.vm.network :forwarded_port, guest: 80, host: 8000 # Apache
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.hostname = $hostname
 
+  # add synced_folder
+  config.vm.synced_folder "sites/all", "/vhosts/digital/web/collections/sites/all"
+
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "utkdigitalbase"
   config.vm.box_url = "http://dlweb.lib.utk.edu/vboxes/utkdigitalbase.json"

--- a/scripts/custom_scripts/070_drush_add_theme.sh
+++ b/scripts/custom_scripts/070_drush_add_theme.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 echo "drush enable theme"
 # Set permissions /sites/all/themes
-sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/themes
-sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/themes
+#sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/themes
+#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/themes
 cd "$DRUPAL_HOME"/sites/all/themes || exit
 
 # Clone UTKdrupal Theme

--- a/scripts/custom_scripts/070_drush_add_theme.sh
+++ b/scripts/custom_scripts/070_drush_add_theme.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 echo "drush enable theme"
 # Set permissions /sites/all/themes
-#sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/themes
-#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/themes
+sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/themes
+sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/themes
 cd "$DRUPAL_HOME"/sites/all/themes || exit
 
 # Clone UTKdrupal Theme

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -10,10 +10,9 @@ fi
 
 # clone default repo
 #  git config core.filemode false
-sudo git clone https://github.com/utkdigitalinitiatives/utk-islandora7-drupal
-
-sudo mv  /vhosts/digital/web/collections/sites/all /vhosts/digital/all-old
-sudo mv  /home/vagrant/utk-islandora7-drupal /vhosts/digital/web/collections/sites/all
+cd "$DRUPAL_HOME"/sites
+sudo rm -rf all
+sudo git clone https://github.com/utkdigitalinitiatives/utk-islandora7-drupal all
 
 # Permissions and ownership
 sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/libraries

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -8,6 +8,8 @@ if [ -f "$SHARED_DIR/configs/variables" ]; then
   . "$SHARED_DIR"/configs/variables
 fi
 
+sudo su apache
+
 # clone repo via https
 cd "$DRUPAL_HOME"/sites || exit
 sudo rm -rf all
@@ -17,6 +19,8 @@ sudo git clone https://github.com/utkdigitalinitiatives/utk-islandora7-drupal al
 cd "$DRUPAL_HOME"/sites/all || exit
 sudo git remote remove origin
 sudo git remote add origin git@github.com:utkdigitalinitiatives/utk-islandora7-drupal.git
+
+sudo su vagrant
 
 # Permissions and ownership
 #sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/libraries

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -8,8 +8,6 @@ if [ -f "$SHARED_DIR/configs/variables" ]; then
   . "$SHARED_DIR"/configs/variables
 fi
 
-sudo su apache
-
 # clone repo via https
 cd "$DRUPAL_HOME"/sites || exit
 sudo rm -rf all
@@ -20,17 +18,15 @@ cd "$DRUPAL_HOME"/sites/all || exit
 sudo git remote remove origin
 sudo git remote add origin git@github.com:utkdigitalinitiatives/utk-islandora7-drupal.git
 
-sudo su vagrant
-
 # Permissions and ownership
-#sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/libraries
-#sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/modules
-#sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/default/files
-#sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/all/modules/custom
-#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/libraries
-#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules
-#sudo chmod -R 755 "$DRUPAL_HOME"/sites/default/files
-#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules/custom
+sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/libraries
+sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/modules
+sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/default/files
+sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/all/modules/custom
+sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/libraries
+sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules
+sudo chmod -R 755 "$DRUPAL_HOME"/sites/default/files
+sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules/custom
 
 
 cd "$DRUPAL_HOME"/sites/all/modules || exit

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -8,21 +8,25 @@ if [ -f "$SHARED_DIR/configs/variables" ]; then
   . "$SHARED_DIR"/configs/variables
 fi
 
-# clone default repo
-#  git config core.filemode false
-cd "$DRUPAL_HOME"/sites
+# clone repo via https
+cd "$DRUPAL_HOME"/sites || exit
 sudo rm -rf all
 sudo git clone https://github.com/utkdigitalinitiatives/utk-islandora7-drupal all
 
+# reset remote origin to use ssh-key
+cd "$DRUPAL_HOME"/sites/all || exit
+sudo git remote remove origin
+sudo git remote add origin git@github.com:utkdigitalinitiatives/utk-islandora7-drupal.git
+
 # Permissions and ownership
-sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/libraries
-sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/modules
-sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/default/files
-sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/all/modules/custom
-sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/libraries
-sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules
-sudo chmod -R 755 "$DRUPAL_HOME"/sites/default/files
-sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules/custom
+#sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/libraries
+#sudo chown -hR vagrant:apache "$DRUPAL_HOME"/sites/all/modules
+#sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/default/files
+#sudo chown -hR apache:apache "$DRUPAL_HOME"/sites/all/modules/custom
+#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/libraries
+#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules
+#sudo chmod -R 755 "$DRUPAL_HOME"/sites/default/files
+#sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules/custom
 
 
 cd "$DRUPAL_HOME"/sites/all/modules || exit


### PR DESCRIPTION
**JIRA Ticket**: [DIGITAL-207](https://jirautk.atlassian.net/browse/DIGITAL-207)

# What does this Pull Request do?

Adds synced directories and permissions for those directories.

# What's new?
Creates a locally mirrored synced directory from vagrant box to allow for a more streamlined workflow in making updates to libraries, modules (including features configuration updates) and theme changes.

# How should this be tested?

1. `vagrant up`
2. your local ./sites/all/ will automatically mirror the directory at /vhosts/digital/web/collections/sites/all/ on your vagrant.
3. `cd sites/all/` in your local directory
4. `git remote -v` and remote for **origin** should be set at _git@github.com:utkdigitalinitiatives/utk-islandora7-drupal.git_

# Additional Notes:
This update largely is focused on synced directories. Additional work related to DIGITAL-207 has been completed by Paul in a separate forked repo.

# Interested parties
@pc37utn 