### PR TITLE
fixes for root fedora object and several modules

### DIFF
--- a/scripts/custom_scripts/update_additional_solr_config.sh
+++ b/scripts/custom_scripts/update_additional_solr_config.sh
@@ -33,7 +33,7 @@ drush vset -y islandora_basic_collection_default_view 'grid'
 drush vset -y islandora_basic_collection_disable_collection_policy_delete 1
 drush vset -y islandora_basic_collection_disable_count_object 0
 drush vset -y islandora_basic_collection_disable_display_generation 0
-drush vset -y islandora_basic_collection_display_backend 'islandora_solr_query_backend'
+#drush vset -y islandora_basic_collection_display_backend 'islandora_solr_query_backend'
 drush vset -y islandora_basic_collection_page_size: '12'
 drush vset -y islandora_collection_metadata_display: 0
 drush vset -y islandora_solr_base_sort: 'score desc, mods_identifier_local_ss asc'

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -69,7 +69,7 @@ drush -y -u 1 en islandora_videojs
 drush -y -u 1 en islandora_fits
 drush -y -u 1 en islandora_ocr
 drush -y -u 1 en islandora_oai
-#drush -y -u 1 en islandora_simple_workflow
+drush -y -u 1 en islandora_transcript
 drush -y -u 1 en islandora_xacml_api islandora_xacml_editor
 drush -y -u 1 en islandora_xmlsitemap
 drush -y -u 1 en islandora_bagit

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -118,6 +118,7 @@ drush -y -u 1 en features context
 cd "$DRUPAL_HOME"/sites/all/modules || exit
 
 # Set variables for Islandora modules
+drush eval "variable_set('islandora_repository_pid', 'islandora:root')"
 drush eval "variable_set('islandora_audio_viewers', array('name' => array('none' => 'none', 'islandora_videojs' => 'islandora_videojs'), 'default' => 'islandora_videojs'))"
 drush eval "variable_set('islandora_fits_executable_path', '$FITS_HOME/fits/fits.sh')"
 drush eval "variable_set('islandora_lame_url', '/usr/bin/lame')"

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -30,41 +30,12 @@ sudo chmod -R 755 "$DRUPAL_HOME"/sites/all/modules/custom
 
 
 cd "$DRUPAL_HOME"/sites/all/modules || exit
-# Clone all non-Islandora modules
-# cd "$DRUPAL_HOME"/sites/all/modules || exit
-#- islandora_bagit -- custom
-# git clone https://github.com/utkdigitalinitiatives/islandora_bagit
-# - utk_lib_feedback
-# git clone https://github.com/utkdigitalinitiatives/utk_lib_feedback
-#- islandora_datastream_replace
-# git clone https://github.com/pc37utn/islandora_datastream_replace
-#git config core.filemode false
 
 # Check for a user's .drush folder, create if it doesn't exist
 if [ ! -d "$HOME_DIR/.drush" ]; then
   mkdir "$HOME_DIR/.drush"
   sudo chown vagrant:vagrant "$HOME_DIR"/.drush
 fi
-
-# Move OpenSeadragon drush file to user's .drush folder
-#if [ -d "$HOME_DIR/.drush" ] && [ -f "$DRUPAL_HOME/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" ]; then
-#  mv "$DRUPAL_HOME/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" "$HOME_DIR/.drush"
-#fi
-
-# Move video.js drush file to user's .drush folder
-#if [ -d "$HOME_DIR/.drush" ] && [ -f "$DRUPAL_HOME/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" ]; then
-#  mv "$DRUPAL_HOME/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" "$HOME_DIR/.drush"
-#fi
-
-# Move pdf.js drush file to user's .drush folder
-#if [ -d "$HOME_DIR/.drush" ] && [ -f "$DRUPAL_HOME/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" ]; then
-#  mv "$DRUPAL_HOME/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" "$HOME_DIR/.drush"
-#fi
-
-# Move IA Bookreader drush file to user's .drush folder
-#if [ -d "$HOME_DIR/.drush" ] && [ -f "$DRUPAL_HOME/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" ]; then
-#  mv "$DRUPAL_HOME/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" "$HOME_DIR/.drush"
-#fi
 
 # Enable Modules
 drush -y -u 1 en libraries 

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -50,6 +50,7 @@ drush -y -u 1 en islandora_basic_image
 drush -y -u 1 en islandora_basic_collection
 drush -y -u 1 en islandora_large_image
 drush -y -u 1 en islandora_internet_archive_bookreader
+drush -y -u 1 en islandora_openseadragon
 drush -y -u 1 en islandora_paged_content
 drush -y -u 1 en colorbox
 drush -y -u 1 en islandora_book 

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -36,7 +36,8 @@ if [ ! -d "$HOME_DIR/.drush" ]; then
   mkdir "$HOME_DIR/.drush"
   sudo chown vagrant:vagrant "$HOME_DIR"/.drush
 fi
-
+# disable modules
+drush -y -u 1 dis xmlsitemap
 # Enable Modules
 drush -y -u 1 en libraries 
 drush -y -u 1 en php_lib islandora objective_forms
@@ -71,7 +72,7 @@ drush -y -u 1 en islandora_ocr
 drush -y -u 1 en islandora_oai
 drush -y -u 1 en islandora_transcript
 drush -y -u 1 en islandora_xacml_api islandora_xacml_editor
-drush -y -u 1 en islandora_xmlsitemap
+#drush -y -u 1 en islandora_xmlsitemap
 drush -y -u 1 en islandora_bagit
 #drush -y -u 1 en islandora_usage_stats
 drush -y -u 1 en islandora_form_fieldpanel


### PR DESCRIPTION
These changes leave the root islandora config setting for fedora to be islandora:root as in the default vagrant. Also the change to the islandora basic collection backend variable  was commented out where it set that to the solr backend.

The islandora transcript module was not getting enabled correctly, probably because of a confusion with the transcript_ui module which is part of the oral histories module.
The openseadragon module was not being enabled.  By default a library has to be downloaded and a script run before this happens, but now that we are using the repo of current modules and libraries, it can be enabled immediately.

To test this:

vagrant up

sign in as admin

see the default islandora objects in pre-made directories like on community vagrant.
anything added at this level ( islandora:root) will have a islandora:1234 or an islandora:your-collection  PID.
@mathewjordan 