### PR TITLE
Fixes build error & adds sshd config

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # add a link to collections from web root ( until we get something else there)
-sudo tee -a /home/vagrant/index.html &>/dev/null <<<EOF
+sudo tee -a /home/vagrant/index.html &>/dev/null <<EOF
 <html><head><title>digital</title></head>
 <body>
  <hr />
@@ -9,6 +9,7 @@ sudo tee -a /home/vagrant/index.html &>/dev/null <<<EOF
 </body>
 </html>
 EOF
+
 sudo mv /home/vagrant/index.html /vhosts/digital/web/
 
 # Set correct permissions on sites/default/files

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -50,3 +50,7 @@ drush block-configure --module=views --delta=usage_collection-usage_stats --regi
 drush block-configure --module=node --delta=recent --region=-1 --weight=0
 drush block-configure --module=node --delta=syndicate --region=-1 --weight=0
 drush block-configure --module=comment --delta=recent --region=-1 --weight=0
+
+# To allow for direct editing from an IDE modify the password authentication via ssh
+sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+service ssh reload

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -53,5 +53,5 @@ drush block-configure --module=node --delta=syndicate --region=-1 --weight=0
 drush block-configure --module=comment --delta=recent --region=-1 --weight=0
 
 # To allow for direct editing from an IDE modify the password authentication via ssh
-sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
-service ssh reload
+sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+sudo service sshd reload


### PR DESCRIPTION
Fixes build error & adds access for IDE to edit. 

## To test

```shell
$ vagrant destroy -f
$ vagrant up
...
    default: The block settings have been updated.                                   [status]
    default: The block settings have been updated.                                   [status]
    default: The block settings have been updated.                                   [status]
    default: Redirecting to /bin/systemctl reload sshd.service

```

Should build without an errors. And now /etc/ssh/sshd_config should have the value of: __PasswordAuthentication yes__