### PR TITLE
Add IIIF Assemble working paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ testjp2
 testtif
 
 # hide local machine sites all
-misc
-misc/*
+misc/assemble
+misc/assemble/*
 sites/all
 sites/all/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ testjp2
 testtif
 
 # hide local machine sites all
+misc
+misc/*
 sites/all
 sites/all/*
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = $hostname
 
   # add synced_folder
+  config.vm.synced_folder "misc/assemble", "/vhosts/digital/web/assemble",
+    owner: "vagrant",
+    group: "apache",
+    mount_options: ["dmode=775,fmode=664"]
+
   config.vm.synced_folder "sites/all", "/vhosts/digital/web/collections/sites/all",
     owner: "vagrant",
     group: "apache",
@@ -43,7 +48,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   shared_dir = "/vagrant"
-
+  config.vm.provision :shell, path: "./scripts/iiif_assemble.sh", :args => shared_dir, :privileged => false
   config.vm.provision :shell, path: "./scripts/islandora_modules.sh", :args => shared_dir, :privileged => false
   config.vm.provision :shell, path: "./scripts/islandora_libraries.sh", :args => shared_dir, :privileged => false
   if File.exist?("./scripts/custom.sh") then

--- a/scripts/iiif_assemble.sh
+++ b/scripts/iiif_assemble.sh
@@ -11,12 +11,12 @@ fi
 # clone repo via https
 cd /vhosts/digital/web || exit
 sudo rm -rf assemble
-sudo git clone https://github.com/mathewjordan/iiif_assemble assemble
+sudo git clone https://github.com/utkdigitalinitiatives/iiif_assemble assemble
 
 # reset remote origin to use ssh-key
 cd assemble
 sudo git remote remove origin
-sudo git remote add origin git@github.com:mathewjordan/iiif_assemble.git
+sudo git remote add origin git@github.com:utkdigitalinitiatives/iiif_assemble.git
 
 echo "Installing Composer"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/scripts/iiif_assemble.sh
+++ b/scripts/iiif_assemble.sh
@@ -18,7 +18,9 @@ cd assemble
 sudo git remote remove origin
 sudo git remote add origin git@github.com:mathewjordan/iiif_assemble.git
 
-# echo "Installing Composer"
-# php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-# php -r "if (hash_file('SHA384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-# sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+echo "Installing Composer"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+HASH="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+php /usr/local/bin/composer install

--- a/scripts/iiif_assemble.sh
+++ b/scripts/iiif_assemble.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Installing the IIIF Assemble & Serve application"
+
+SHARED_DIR=$1
+
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . "$SHARED_DIR"/configs/variables
+fi
+
+# clone repo via https
+cd /vhosts/digital/web || exit
+sudo rm -rf assemble
+sudo git clone https://github.com/mathewjordan/iiif_assemble assemble
+
+# reset remote origin to use ssh-key
+cd assemble
+sudo git remote remove origin
+sudo git remote add origin git@github.com:mathewjordan/iiif_assemble.git
+
+# echo "Installing Composer"
+# php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+# php -r "if (hash_file('SHA384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+# sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
# What does this Pull Request do?

Adds synced directories for the IIIF Assemble app at https://github.com/utkdigitalinitiatives/iiif_assemble

# What's new?
Creates a locally mirrored synced directory from vagrant box to allow for development alongside an Islandora 7 instance with Fedora 3.8.

# How should this be tested?

1. `vagrant up`
2. _If necessary_, follow https://github.com/utkdigitalinitiatives/iiif_assemble#add-the-collection-record
3. _If necessary_, follow  https://github.com/utkdigitalinitiatives/iiif_assemble#ingest-a-couple-of-sample-records
4. Follow https://github.com/utkdigitalinitiatives/iiif_assemble#allow-htaccess-overrides
5. Test at route http://localhost:8000/assemble/manifest/{namepsace}/{id} where **namespace** is a string and **id** is a positive integer. The example route of `/assemble/manifest/rfta/1` will correlate to `rfta:1`

# Additional Notes:
Some additional future work can be handled in a new PR to make **Step 4** unnecessary